### PR TITLE
adding secondary ordering for time

### DIFF
--- a/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/data/BedSedimentDownloadSpec.java
+++ b/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/data/BedSedimentDownloadSpec.java
@@ -54,7 +54,7 @@ public class BedSedimentDownloadSpec extends Spec implements CentralizableTimezo
 			new ColumnMapping(C_STATION_NAME, S_STATION_NAME),
 			new ColumnMapping(C_STATION_NUM, S_STATION_NUM),
 			new ColumnMapping(C_BED_DATE, QWDownloadSpec.SE_DEFAULT_ORDERING, ASCENDING_ORDER, S_BED_DATE, null, null, null, "TO_CHAR(" + C_BED_DATE + ", 'YYYY-MM-DD')", null, null),
-			new ColumnMapping(C_BED_TIME, S_BED_TIME, ASCENDING_ORDER, S_BED_TIME + " (" + getTimezoneDisplay() + ")", null, null, null, "TO_CHAR(" + C_BED_TIME + ", 'HH24:MI:SS')", null, null),
+			new ColumnMapping(C_BED_TIME, QWDownloadSpec.SE_SECONDARY_ORDERING, ASCENDING_ORDER, S_BED_TIME + " (" + getTimezoneDisplay() + ")", null, null, null, "TO_CHAR(" + C_BED_TIME + ", 'HH24:MI:SS')", null, null),
 			new ColumnMapping(C_SAMPLE_SET, S_SAMPLE_SET),
 			new ColumnMapping(C_NOTES, S_NOTES),
 			new ColumnMapping(C_STATION_LOCATION, S_STATION_LOCATION),

--- a/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/data/DownloadService.java
+++ b/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/data/DownloadService.java
@@ -39,7 +39,7 @@ public class DownloadService extends WebService {
 		result.putAll(super.defineParameters(req, router, params));
 		
 		if (!result.containsKey(Spec.ORDER_BY_PARAM)) {
-			result.put(Spec.ORDER_BY_PARAM, new String[] {QWDownloadSpec.SE_DEFAULT_ORDERING});
+			result.put(Spec.ORDER_BY_PARAM, new String[] {QWDownloadSpec.SE_DEFAULT_ORDERING+","+QWDownloadSpec.SE_SECONDARY_ORDERING});
 		}
 		
 		return result;

--- a/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/data/QWDownloadSpec.java
+++ b/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/data/QWDownloadSpec.java
@@ -599,6 +599,7 @@ public class QWDownloadSpec extends Spec implements CentralizableTimezone {
 	public static final String S_SAND_D50_TOT_95ER = "95%-confidence-level total error in sand D50(mm)";
 	
 	public static final String SE_DEFAULT_ORDERING = "defaultOrder";
+	public static final String SE_SECONDARY_ORDERING = "secondaryOrder";
 	
 	public static final String SE_SAMPLE_ID = "sampleId";
 	public static final String SE_STATION_NAME = "stationName";


### PR DESCRIPTION
I noticed we were only ordering by Date for Bed Material, so within day entries were misordered.