### PR TITLE
Revert "Attempt to include SQL hint for old optimizer"

### DIFF
--- a/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/data/ParameterSpec.java
+++ b/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/data/ParameterSpec.java
@@ -73,7 +73,7 @@ public class ParameterSpec extends DataSpec {
 	public String setupTableName() {
 		StringBuilder result = new StringBuilder();
 		
-		result.append("  (SELECT /*+ OPT_PARAM('optimizer_features_enable' '11.2.0.3') */ MEASUREMENT_DATE AS TSM_DT,");
+		result.append("  (SELECT MEASUREMENT_DATE AS TSM_DT,");
 		result.append("    FINAL_VALUE,");
 		result.append("    RAW_VALUE,");
 		result.append("    MAIN_QUALIFIER,");

--- a/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/station/StationParamSpec.java
+++ b/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/station/StationParamSpec.java
@@ -77,8 +77,8 @@ public class StationParamSpec extends GCMRCSpec {
 	@Override
 	public String setupTableName() {
 		StringBuilder result = new StringBuilder();
-
-		result.append("  (SELECT /*+ OPT_PARAM('optimizer_features_enable' '11.2.0.3') */ T_POR.GROUP_ID,");
+		
+		result.append("  (SELECT T_POR.GROUP_ID,");
 		result.append("    GROUP_NAME,");
 		result.append("    SITE_NAME,");
 		result.append("    SITE_DISPLAY_NAME,");

--- a/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/station/StationSiteSpec.java
+++ b/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/station/StationSiteSpec.java
@@ -68,8 +68,8 @@ public class StationSiteSpec extends GCMRCSpec {
 	@Override
 	public String setupTableName() {
 		StringBuilder result = new StringBuilder();
-	
-		result.append("(SELECT /*+ OPT_PARAM('optimizer_features_enable' '11.2.0.3') */ DISTINCT");
+		
+		result.append("(SELECT DISTINCT");
 		result.append("  TSD.SITE_ID,");
 		result.append("  CASE");
 		result.append("    WHEN NWIS_SITE_NO IS NULL");

--- a/gcmrc-services/src/main/resources/gov/usgs/cida/gcmrcservices/mb/mappers/ReachDetailMapper.xml
+++ b/gcmrc-services/src/main/resources/gov/usgs/cida/gcmrcservices/mb/mappers/ReachDetailMapper.xml
@@ -25,7 +25,6 @@
 	
 	<select id="getReachDetails" parameterType="map" resultMap="reachDetailResult">
 		SELECT
-		/*+ OPT_PARAM('optimizer_features_enable' '11.2.0.3') */
 		<include refid="columns"/>
 		FROM
 			(SELECT DISTINCT

--- a/gcmrc-services/src/main/resources/gov/usgs/cida/gcmrcservices/mb/mappers/ReachMapper.xml
+++ b/gcmrc-services/src/main/resources/gov/usgs/cida/gcmrcservices/mb/mappers/ReachMapper.xml
@@ -41,7 +41,6 @@
 	
 	<select id="getReaches" parameterType="map" resultMap="reachResult">
 		SELECT
-		/*+ OPT_PARAM('optimizer_features_enable' '11.2.0.3') */
 		<include refid="columns"/>
 		FROM
   (SELECT DISTINCT RTD.REACH_NAME,


### PR DESCRIPTION
Reverts USGS-CIDA/gcmrc-ui-parent#35

This takes out the individual additions of the optimizer hints.  This has been replaced w/ PR #36, which adds it for all queries.