### PR TITLE
Gcmon 337 slow queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,8 +309,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.5.1</version>
 				<configuration>
-					<source>${java.version>}</source>
-					<target>${java.version>}</target>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Typo’ed the pom files, resulting in a broken build on Jenkins.