### PR TITLE
Final Cleanup w/ trace logging turned off and JDBCSpec release

### DIFF
--- a/gcmrc-services/src/main/resources/logback.xml
+++ b/gcmrc-services/src/main/resources/logback.xml
@@ -11,7 +11,7 @@
 <!--		<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
 			<level>TRACE</level>
 		</filter>-->
-		<file>${catalina.base}/logs/gcmrc-test.log</file>
+		<file>${catalina.base}/logs/gcmrc.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
 			<fileNamePattern>${catalina.base}/logs/gcmrc/gcmrc-services.%d{yyyy-MM-dd}.log</fileNamePattern>
 			<maxHistory>7</maxHistory>
@@ -34,7 +34,7 @@
 	Slow queries (queries that take over 30 seconds to return w/ init results)
 	will be logged by default at the WARN level, and will include full SQL and params.
 	-->
-	<logger name="gov.usgs.webservices.jdbc.spec.Spec" level="TRACE"/>
+	<!-- <logger name="gov.usgs.webservices.jdbc.spec.Spec" level="TRACE"/> -->
 	<logger name="gov.usgs.webservices.jdbc.service" level="DEBUG"/>
 	<logger name="gov.usgs.cida.nude" level="DEBUG"/>
 	<logger name="gov.usgs.cida.nude.filter" level="INFO"/>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
 			<dependency>
 				<groupId>gov.usgs.cida</groupId>
 				<artifactId>jdbc-spec-library</artifactId>
-				<version>0.5.13</version>
+				<version>0.5.14</version>
 				<exclusions>
 					<exclusion>
 						<artifactId>log4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
 			<dependency>
 				<groupId>gov.usgs.cida</groupId>
 				<artifactId>jdbc-spec-library</artifactId>
-				<version>0.5.13-SNAPSHOT</version>
+				<version>0.5.13</version>
 				<exclusions>
 					<exclusion>
 						<artifactId>log4j</artifactId>


### PR DESCRIPTION
This needs to wait to be merged until the JDBC Spec Lib successfully releases 0.5.13.