### PR TITLE
Gcmon 337 slow queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,14 @@
 						<warSourceDirectory>${war.dir}</warSourceDirectory>
 					</configuration>
 				</plugin>
+				<plugin>
+				  <groupId>org.apache.maven.plugins</groupId>
+				  <artifactId>maven-javadoc-plugin</artifactId>
+				  <version>2.10.3</version>
+				  <configuration>
+					<additionalparam>-Xdoclint:none</additionalparam>
+				  </configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
Fix for releases failing due to overly-strict javadoc lint.