### PR TITLE
Experimental change turning off explicit fetchSize (was set to 2000)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
 			<dependency>
 				<groupId>gov.usgs.cida</groupId>
 				<artifactId>jdbc-spec-library</artifactId>
-				<version>0.5.14</version>
+				<version>0.5.14.1</version>
 				<exclusions>
 					<exclusion>
 						<artifactId>log4j</artifactId>


### PR DESCRIPTION
Now allowing the jdbc driver to default, which would be 10 rows per fetch.