### PR TITLE
Gcmon 366 upgrade proxy version and extend timeout

### DIFF
--- a/gcmrc-ui/pom.xml
+++ b/gcmrc-ui/pom.xml
@@ -17,23 +17,11 @@
 			<artifactId>proxy-utils</artifactId>
 			<groupId>gov.usgs.cida</groupId>
 		</dependency>
-<!--		<dependency>
-			<groupId>gov.usgs.cida.imageproxy</groupId>
-			<artifactId>imageproxy</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
-			<scope>compile</scope>
-		</dependency>-->
-<!--		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
-		</dependency>
 		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.1</version>
-		</dependency>-->
-		<!-- LOGGING -->
+			<!-- Required by proxy-utils -> httpclient -->
+			<artifactId>commons-logging</artifactId>
+			<groupId>commons-logging</groupId>
+		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>

--- a/gcmrc-ui/pom.xml
+++ b/gcmrc-ui/pom.xml
@@ -17,6 +17,7 @@
 			<artifactId>proxy-utils</artifactId>
 			<groupId>gov.usgs.cida</groupId>
 		</dependency>
+		<!-- LOGGING -->
 		<dependency>
 			<!-- Required by proxy-utils -> httpclient -->
 			<artifactId>commons-logging</artifactId>

--- a/gcmrc-ui/src/main/webapp/WEB-INF/web.xml
+++ b/gcmrc-ui/src/main/webapp/WEB-INF/web.xml
@@ -65,14 +65,30 @@
 	<servlet>
 		<servlet-name>GCMRCServicesServlet</servlet-name>
 		<servlet-class>gov.usgs.cida.proxy.AlternateProxyServlet</servlet-class>
-		<init-param>
-			<param-name>forward-url-param</param-name>
-			<param-value>gcmrc.services-url</param-value>
-		</init-param>
-		<init-param>
+		<init-param> <!-- The url to forward incoming requests to -->
 			<param-name>forward-url</param-name>
 			<param-value>http://localhost:8080/gcmrc-services/</param-value>
 		</init-param>
+		<init-param>
+			<!-- Allows overridding forward-url in context.xml with 'gcmrc.services-url' -->
+			<param-name>forward-url-param</param-name>
+			<param-value>gcmrc.services-url</param-value>
+		</init-param>
+
+		<init-param>
+			<!-- 15*60*1000 = 900,000 ms = 15 minutes (default is 5 min)
+			This is the timeout between chunks of data being received.
+			For long queries where data is loaded and build b/f any data can be
+			sent, it easy to go past the default 5 min. -->
+			<param-name>client-socket-timeout</param-name>
+			<param-value>900000</param-value>
+		</init-param>
+		<init-param>
+			<!-- Allows overridding client-socket-timeout in context.xml with 'client-socket-timeout-param' -->
+			<param-name>client-socket-timeout-param</param-name>
+			<param-value>client-socket-timeout-param</param-value>
+		</init-param>
+
 	</servlet>
 	<servlet-mapping>
 		<servlet-name>GCMRCServicesServlet</servlet-name>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
 			<dependency>
 				<groupId>gov.usgs.cida</groupId>
 				<artifactId>jdbc-spec-library</artifactId>
-				<version>0.5.14.1</version>
+				<version>0.5.14.2</version>
 				<exclusions>
 					<exclusion>
 						<artifactId>log4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -204,8 +204,15 @@
 			<dependency>
 				<artifactId>proxy-utils</artifactId>
 				<groupId>gov.usgs.cida</groupId>
-				<type>jar</type>
-				<version>1.0.5</version>
+				<version>1.0.12</version>
+			</dependency>
+			<dependency>
+				<!-- Required by httpclient, which is used by proxy-utils.
+				Though required, it is excluded in proxy-utils pom, so must
+				be included when used in a project -->
+				<artifactId>commons-logging</artifactId>
+				<groupId>commons-logging</groupId>
+				<version>1.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mybatis</groupId>


### PR DESCRIPTION
Expand socket timeout for proxy so long queries don't timeout
* Upgraded from proxy-utils 1.05 to 1.0.12, which adds configurable socket timeouts
* Upgrade requires commons-logging, so that was added as well
* Added config for 15 min socket time to web.xml file (default is 5 min)
* RM commented out config and added comments to related code