### PR TITLE
Gcmon 354 investigate various timeouts for gcmrc

### DIFF
--- a/gcmrc-ui/src/main/webapp/app/graphing/graphing.js
+++ b/gcmrc-ui/src/main/webapp/app/graphing/graphing.js
@@ -307,7 +307,7 @@ GCMRC.Graphing = function(hoursOffset) {
 				dataType: 'json',
 				url: CONFIG.relativePath + urls[param],
 				data: urlParams,
-				timeout: 600000,
+				timeout: 1200000, /* 20 minutes allowed, from start to data complete */
 				success: function(data, textStatus, jqXHR) {
 					if (!data || (!data.contentType && data.contentType === "text/xml")) {
 						clearErrorMessage();

--- a/gcmrc-ui/src/main/webapp/app/graphing/graphing.js
+++ b/gcmrc-ui/src/main/webapp/app/graphing/graphing.js
@@ -366,9 +366,25 @@ GCMRC.Graphing = function(hoursOffset) {
 						}
 					}
 				},
-				error: function() {
+				error: function(jqXHR, textStatus, errorThrown) {
 					clearErrorMessage();
-					showErrorMessage("A Network Error has occurred. Please check your configuration and try again.  If you repeatedly receive this message, contact <a href='mailto:" + GCMRC.administrator + "@usgs.gov'>" + GCMRC.administrator + "@usgs.gov</a>");
+					var msg = "";
+					switch(textStatus) {
+						case 'timeout':
+							msg = "The browser timed out waiting for a response from the server.";
+						break;
+						case 'abort':
+							msg = "The request was aborted.";
+						break;
+						case 'parsererror':
+							msg = "A response was received, but it was unreadable.";
+						break;
+						case 'error':
+						//break; fall thru
+					default:
+						msg = "Some type of server or network error occured.";
+					}
+					showErrorMessage("Your request could not be completed.  Reason: '" + msg + "'  If you repeatedly receive this message, contact <a href='mailto:" + GCMRC.administrator + "@usgs.gov'>" + GCMRC.administrator + "@usgs.gov</a>");
 				}
 			});
 		}


### PR DESCRIPTION
Increased the UI timeout from 10 minutes to 20 minutes, since this is the complete start of completed/all data received time.  We know we have some requests that run as long as 15 minutes.  Also improved the reporting of errors so that it would be obvious if the error was a UI timeout.