### PR TITLE
GCMON-370: Switched duration curve plotting style from dots to lines

### DIFF
--- a/gcmrc-ui/src/main/webapp/app/graphing/graphing.js
+++ b/gcmrc-ui/src/main/webapp/app/graphing/graphing.js
@@ -439,10 +439,9 @@ GCMRC.Graphing = function(hoursOffset) {
 			strokeWidth: 2,
 			pixelsPerTimeLabel : 95,
 			ticker: GCMRC.Dygraphs.ScaledTicker(decimalPlaces),
-			plotter: GCMRC.Dygraphs.DotPlotter,
 			drawHighlightPointCallback: lighterColorHighlightPoint,
 			customBars: true,
-			drawPoints: true,
+			drawPoints: false,
 			stackedGraph: false,
 			colors: confColors,
 			drawCallback: function(me, initial) {

--- a/gcmrc-ui/src/main/webapp/pages/stationview/onReady.js
+++ b/gcmrc-ui/src/main/webapp/pages/stationview/onReady.js
@@ -55,9 +55,9 @@ $(document).ready(function() {
 
 	$('#loading').ajaxStart(function() {
 		$(this).show();
-		$('.buildButton').addClass("disabled");
+		$('.buildButton').hide();
 	}).ajaxStop(function() {
 		$(this).hide();
-		$('.buildButton').removeClass("disabled");
+		$('.buildButton').show();
 	});
 });


### PR DESCRIPTION
Also made build and download buttons disappear during graph building so that users cannot initiate multiple simultaneous graph builds.