### PR TITLE
GCMON-486: Updated duration curve request from UI to filter out...

### DIFF
--- a/gcmrc-ui/src/main/webapp/app/graphing/graphing.js
+++ b/gcmrc-ui/src/main/webapp/app/graphing/graphing.js
@@ -17,6 +17,8 @@ GCMRC.Graphing = function(hoursOffset) {
 		agg: 'services/agg/',
 		durationCurve: 'services/rest/durationcurve/'
 	};
+	
+	var NO_DURATION_CURVE_IDS = ["14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52"];
 
 	var showInfoMessage = function(locator, msg) {
 		$(locator).append('<div class="alert alert-info"><button type="button" class="close" data-dismiss="alert">×</button>' + msg + '</div>');
@@ -516,7 +518,17 @@ GCMRC.Graphing = function(hoursOffset) {
 	};
 	
 	var createDurationCurvePlot = function(param, config, urlParams) {
-		urlParams.groupId = config.graphsToMake;
+		
+		//Filter out requested groupids that will never have duration curves (bed sediment params)
+		var validIds = new Array();
+		
+		config.graphsToMake.forEach(function(elem) {
+			if(NO_DURATION_CURVE_IDS.indexOf(elem) === -1){
+				validIds.add(elem);
+			}
+		});
+		
+		urlParams.groupId = validIds;
 		
 		$.ajax({
 			jsonp: "jsonp_callback",

--- a/gcmrc-ui/src/main/webapp/app/graphing/graphing.js
+++ b/gcmrc-ui/src/main/webapp/app/graphing/graphing.js
@@ -674,6 +674,7 @@ GCMRC.Graphing = function(hoursOffset) {
 		clearWarningMsg : clearWarningMessage,
 		showErrorMsg : showErrorMessage,
 		clearErrorMsg : clearErrorMessage,
+		NO_DURATION_CURVE_IDS : NO_DURATION_CURVE_IDS,
 		createDataGraph: function(param, config, urlParams) {
 			$('#infoMsg').empty();
 			$("#errorMsg").empty();

--- a/gcmrc-ui/src/main/webapp/pages/stationview/page.js
+++ b/gcmrc-ui/src/main/webapp/pages/stationview/page.js
@@ -307,11 +307,14 @@ GCMRC.Page = {
 		var chosenParameters = $('.parameterListing input:checkbox:checked');
 		result = $.map(chosenParameters, function(el, i) {
 			var result = [];
-
-			result.push({
-				groupId: el.name,
-				name: GCMRC.Page.params[el.name].description.displayName
-			});
+			//Filter out groupIds that will never have valid duration curve data
+			if(GCMRC.Graphing.NO_DURATION_CURVE_IDS.indexOf(el.name) === -1){
+				result.push({
+					groupId: el.name,
+					name: GCMRC.Page.params[el.name].description.displayName
+				});
+			}
+			
 			return result;
 		});
 		return result;
@@ -577,7 +580,7 @@ GCMRC.Page = {
 				$('#downloadPopup').modal();
 			} else {
 				GCMRC.Graphing.clearErrorMsg();
-				GCMRC.Graphing.showErrorMsg("No data selected!");
+				GCMRC.Graphing.showErrorMsg("No parameters selected or no data avilable for the selected parameters in the selected date range.");
 			}
 		} else {
 			GCMRC.Graphing.clearErrorMsg();


### PR DESCRIPTION
... groupIds that will never have valid duration curve data so that the error message does not show up when those params have no duration curve data returned.