### PR TITLE
more https changes

### DIFF
--- a/gcmrc-ui/src/main/webapp/app/mapping.js
+++ b/gcmrc-ui/src/main/webapp/app/mapping.js
@@ -14,7 +14,7 @@ GCMRC.Mapping = function() {
 	var layers = {
 		esri : {
 		esriWorldImagery: new OpenLayers.Layer.XYZ("World Imagery",
-				"http://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/${z}/${y}/${x}",
+				"https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/${z}/${y}/${x}",
 				{
 					sphericalMercator: true,
 					isBaseLayer: true,
@@ -23,7 +23,7 @@ GCMRC.Mapping = function() {
 				}
 		),
 		esriStreet: new OpenLayers.Layer.XYZ("Street",
-				"http://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/${z}/${y}/${x}",
+				"https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/${z}/${y}/${x}",
 				{
 					sphericalMercator: true,
 					isBaseLayer: true,
@@ -32,7 +32,7 @@ GCMRC.Mapping = function() {
 				}
 		),
 		esriTopo: new OpenLayers.Layer.XYZ("Topo",
-				"http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/${z}/${y}/${x}",
+				"https://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/${z}/${y}/${x}",
 				{
 					sphericalMercator: true,
 					isBaseLayer: true,
@@ -41,7 +41,7 @@ GCMRC.Mapping = function() {
 				}
 		),
 		esriTerrain: new OpenLayers.Layer.XYZ("Terrain",
-				"http://services.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/${z}/${y}/${x}",
+				"https://services.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/${z}/${y}/${x}",
 				{
 					sphericalMercator: true,
 					isBaseLayer: true,
@@ -50,7 +50,7 @@ GCMRC.Mapping = function() {
 				}
 		),
 		esriShadedRelief: new OpenLayers.Layer.XYZ("Shaded Relief",
-				"http://services.arcgisonline.com/ArcGIS/rest/services/World_Shaded_Relief/MapServer/tile/${z}/${y}/${x}",
+				"https://services.arcgisonline.com/ArcGIS/rest/services/World_Shaded_Relief/MapServer/tile/${z}/${y}/${x}",
 				{
 					sphericalMercator: true,
 					isBaseLayer: true,
@@ -59,7 +59,7 @@ GCMRC.Mapping = function() {
 				}
 		),
 		esriPhysical: new OpenLayers.Layer.XYZ("Physical",
-				"http://services.arcgisonline.com/ArcGIS/rest/services/World_Physical_Map/MapServer/tile/${z}/${y}/${x}",
+				"https://services.arcgisonline.com/ArcGIS/rest/services/World_Physical_Map/MapServer/tile/${z}/${y}/${x}",
 				{
 					sphericalMercator: true,
 					isBaseLayer: true,
@@ -68,7 +68,7 @@ GCMRC.Mapping = function() {
 				}
 		),
 		esriOcean: new OpenLayers.Layer.XYZ("Ocean",
-				"http://services.arcgisonline.com/ArcGIS/rest/services/Ocean_Basemap/MapServer/tile/${z}/${y}/${x}",
+				"https://services.arcgisonline.com/ArcGIS/rest/services/Ocean_Basemap/MapServer/tile/${z}/${y}/${x}",
 				{
 					sphericalMercator: true,
 					isBaseLayer: true,
@@ -146,7 +146,7 @@ GCMRC.Mapping = function() {
 				})
 			}),
 		satmap : new OpenLayers.Layer.ArcGIS93Rest( "ArcGIS Server Layer",
-                "http://137.227.239.42/ArcGIS/rest/services/GC_2009_05_4BAND_EARTHDATA/ImageServer/exportImage",
+                "https://137.227.239.42/ArcGIS/rest/services/GC_2009_05_4BAND_EARTHDATA/ImageServer/exportImage",
                 {
 					layers: "show:0",
 					srs : "EPSG:26949"

--- a/gcmrc-ui/src/main/webapp/app/orgs.js
+++ b/gcmrc-ui/src/main/webapp/app/orgs.js
@@ -1,7 +1,7 @@
 GCMRC.Organizations = {
 	"CIDA" : {
 		displayName : "USGS Center for Integrated Data Analytics",
-		url : "http://cida.usgs.gov",
+		url : "https://cida.usgs.gov",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-cida.gif",
 			width : 80,
@@ -10,7 +10,7 @@ GCMRC.Organizations = {
 	},
 	"USGSGCMR" : {
 		displayName : "Grand Canyon Monitoring and Research Center",
-		url : "http://www.gcmrc.gov/",
+		url : "https://www.gcmrc.gov/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-usgs.gif",
 			width : 80,
@@ -19,7 +19,7 @@ GCMRC.Organizations = {
 	},
 	"USGSCOWC" : {
 		displayName : "Colorado Water Science Center",
-		url : "http://co.water.usgs.gov/",
+		url : "https://co.water.usgs.gov/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-usgs.gif",
 			width : 80,
@@ -28,7 +28,7 @@ GCMRC.Organizations = {
 	},
 	"USGSUTWC" : {
 		displayName : "Utah Water Science Center",
-		url : "http://ut.water.usgs.gov/",
+		url : "https://ut.water.usgs.gov/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-usgs.gif",
 			width : 80,
@@ -37,7 +37,7 @@ GCMRC.Organizations = {
 	},
 	"USGSTXWC" : {
 		displayName : "Texas Water Science Center",
-		url : "http://tx.usgs.gov",
+		url : "https://tx.usgs.gov",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-usgs.gif",
 			width : 80,
@@ -46,7 +46,7 @@ GCMRC.Organizations = {
 	},
 	"USGSAZWC" : {
 		displayName : "Arizona Water Science Center",
-		url : "http://az.water.usgs.gov/",
+		url : "https://az.water.usgs.gov/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-usgs.gif",
 			width : 80,
@@ -55,7 +55,7 @@ GCMRC.Organizations = {
 	},
 	"UTSU" : {
 		displayName : "Utah State University",
-		url : "http://www.usu.edu/",
+		url : "https://www.usu.edu/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-usu.gif",
 			width : 106,
@@ -64,7 +64,7 @@ GCMRC.Organizations = {
 	},
 	"USBR" : {
 		displayName : "Bureau of Reclaimation",
-		url : "http://www.usbr.gov/",
+		url : "https://www.usbr.gov/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-usbr.gif",
 			width : 88,
@@ -73,7 +73,7 @@ GCMRC.Organizations = {
 	},
 	"NPS" : {
 		displayName : "National Park Service",
-		url : "http://www.nps.gov/",
+		url : "https://www.nps.gov/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-nps.gif",
 			width : 34,
@@ -82,7 +82,7 @@ GCMRC.Organizations = {
 	},
 	"BLM" : {
 		displayName : "Bureau of Land Management",
-		url : "http://www.blm.gov/",
+		url : "https://www.blm.gov/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-blm.gif",
 			width : 43,
@@ -91,7 +91,7 @@ GCMRC.Organizations = {
 	},
 	"CEC" : {
 		displayName : "Commission for Environmental Cooperation",
-		url : "http://www.cec.org/",
+		url : "https://www.cec.org/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-cec.gif",
 			width : 45,
@@ -100,7 +100,7 @@ GCMRC.Organizations = {
 	},
 	"USIBWC" : {
 		displayName : "U.S. International Boundary and Water Commission",
-		url : "http://www.ibwc.gov/home.html",
+		url : "https://www.ibwc.gov/home.html",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-ibwc.jpg",
 			width : 40,
@@ -109,7 +109,7 @@ GCMRC.Organizations = {
 	},
 	"IIUABC" : {
 		displayName : "Instituto de Ingeniería UABC",
-		url : "http://institutodeingenieria.uabc.mx/",
+		url : "https://institutodeingenieria.uabc.mx/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-iiuabc.jpg",
 			width : 136,

--- a/gcmrc-ui/src/main/webapp/app/orgs.js
+++ b/gcmrc-ui/src/main/webapp/app/orgs.js
@@ -19,7 +19,7 @@ GCMRC.Organizations = {
 	},
 	"USGSCOWC" : {
 		displayName : "Colorado Water Science Center",
-		url : "https://co.water.usgs.gov/",
+		url : "http://co.water.usgs.gov/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-usgs.gif",
 			width : 80,
@@ -28,7 +28,7 @@ GCMRC.Organizations = {
 	},
 	"USGSUTWC" : {
 		displayName : "Utah Water Science Center",
-		url : "https://ut.water.usgs.gov/",
+		url : "http://ut.water.usgs.gov/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-usgs.gif",
 			width : 80,
@@ -46,7 +46,7 @@ GCMRC.Organizations = {
 	},
 	"USGSAZWC" : {
 		displayName : "Arizona Water Science Center",
-		url : "https://az.water.usgs.gov/",
+		url : "http://az.water.usgs.gov/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-usgs.gif",
 			width : 80,
@@ -55,7 +55,7 @@ GCMRC.Organizations = {
 	},
 	"UTSU" : {
 		displayName : "Utah State University",
-		url : "https://www.usu.edu/",
+		url : "http://www.usu.edu/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-usu.gif",
 			width : 106,
@@ -91,7 +91,7 @@ GCMRC.Organizations = {
 	},
 	"CEC" : {
 		displayName : "Commission for Environmental Cooperation",
-		url : "https://www.cec.org/",
+		url : "http://www.cec.org/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-cec.gif",
 			width : 45,
@@ -100,7 +100,7 @@ GCMRC.Organizations = {
 	},
 	"USIBWC" : {
 		displayName : "U.S. International Boundary and Water Commission",
-		url : "https://www.ibwc.gov/home.html",
+		url : "http://www.ibwc.gov/home.html",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-ibwc.jpg",
 			width : 40,
@@ -109,7 +109,7 @@ GCMRC.Organizations = {
 	},
 	"IIUABC" : {
 		displayName : "Instituto de Ingeniería UABC",
-		url : "https://institutodeingenieria.uabc.mx/",
+		url : "http://institutodeingenieria.uabc.mx/",
 		logo : {
 			url : CONFIG.relativePath + "app/sources/source-iiuabc.jpg",
 			width : 136,

--- a/gcmrc-ui/src/main/webapp/index.jsp
+++ b/gcmrc-ui/src/main/webapp/index.jsp
@@ -85,7 +85,7 @@
 					<h2>Discharge, Sediment, and Water Quality Monitoring</h2>
 					<div id="breadcrumbs" class="row-fluid">
 						<span>
-							<span><a href="http://www.gcmrc.gov/gcmrc.aspx">Home</a></span>
+							<span><a href="https://www.gcmrc.gov/gcmrc.aspx">Home</a></span>
 							<span> &gt; </span>
 							<span>Discharge, Sediment and Water Quality</span>
 						</span>
@@ -133,7 +133,7 @@
 									</div>
 								</div>
 								<div class="media">
-									<a class="pull-left" href="http://cida.usgs.gov/"><img class="media-object" src="./template/images/source-cida.gif"></a>
+									<a class="pull-left" href="https://cida.usgs.gov/"><img class="media-object" src="./template/images/source-cida.gif"></a>
 									<div class="media-body">
 										<h5 class="media-heading">Website Design and Programming</h5>
 										<ul class="unstyled">
@@ -152,7 +152,7 @@
 							<div class="sectionWideTitle">Cooperating Agencies and Academic Institutions</div>
 							<div class="well half">
 								<div class="media">
-									<a href="http://www.usbr.gov/">
+									<a href="https://www.usbr.gov/">
 										<div class="media-object pull-left" style="width:106px; text-align: center;"><img src="./template/images/source-usbr.gif"></div>
 										<div class="media-body">
 											<h4 class="media-heading">Bureau of Reclamation</h4>
@@ -160,7 +160,7 @@
 									</a>
 								</div>
 								<div class="media">
-									<a href="http://www.nps.gov/">
+									<a href="https://www.nps.gov/">
 										<div class="media-object pull-left" style="width:106px; text-align: center;"><img src="./template/images/source-nps.gif"></div>
 										<div class="media-body">
 											<h4 class="media-heading">National Park Service</h4>
@@ -168,7 +168,7 @@
 									</a>
 								</div>
 								<div class="media">
-									<a href="http://www.blm.gov/">
+									<a href="https://www.blm.gov/">
 										<div class="media-object pull-left" style="width:106px; text-align: center;"><img src="./template/images/source-blm.jpg"></div>
 										<div class="media-body">
 											<h4 class="media-heading">Bureau of Land Management</h4>
@@ -219,7 +219,7 @@
 									</a>
 								</div>
 								<div class="media">
-									<a href="http://tx.usgs.gov/">
+									<a href="https://tx.usgs.gov/">
 										<!--<img class="media-object pull-left" src="app/sources/source-usgs.gif">-->
 										<div class="media-body">
 											<h4 class="media-heading">Texas Water Science Center</h4>

--- a/gcmrc-ui/src/main/webapp/networkreachview.jsp
+++ b/gcmrc-ui/src/main/webapp/networkreachview.jsp
@@ -94,7 +94,7 @@
 				<h2><span class="network-name"></span> Reaches</h2>
 				<div id="breadcrumbs">
 					<span>
-						<span><a href="http://www.gcmrc.gov/gcmrc.aspx">Home</a></span>
+						<span><a href="https://www.gcmrc.gov/gcmrc.aspx">Home</a></span>
 						<span> &gt; </span>
 						<span><a href="${relativePath}index.jsp">Discharge, Sediment and Water Quality</a></span>
 						<span> &gt; </span>

--- a/gcmrc-ui/src/main/webapp/networkstationview.jsp
+++ b/gcmrc-ui/src/main/webapp/networkstationview.jsp
@@ -103,7 +103,7 @@
 					<h2><span class="network-name"></span> Stations</h2>
 					<div id="breadcrumbs">
 						<span>
-							<span><a href="http://www.gcmrc.gov/gcmrc.aspx">Home</a></span>
+							<span><a href="https://www.gcmrc.gov/gcmrc.aspx">Home</a></span>
 							<span> &gt; </span>
 							<span><a href="${relativePath}index.jsp">Discharge, Sediment and Water Quality</a></span>
 						<span> &gt; </span>

--- a/gcmrc-ui/src/main/webapp/reachview.jsp
+++ b/gcmrc-ui/src/main/webapp/reachview.jsp
@@ -179,7 +179,7 @@
 				<h2><span id="station-title"></span> <small id="station-subtitle"></small></h2>
 				<div id="breadcrumbs">
 					<span>
-						<span><a href="http://www.gcmrc.gov/gcmrc.aspx">Home</a></span>
+						<span><a href="https://www.gcmrc.gov/gcmrc.aspx">Home</a></span>
 						<span> &gt; </span>
 						<span><a href="${relativePath}index.jsp">Discharge, Sediment and Water Quality</a></span>
 						<span> &gt; </span>

--- a/gcmrc-ui/src/main/webapp/stationview.jsp
+++ b/gcmrc-ui/src/main/webapp/stationview.jsp
@@ -175,7 +175,7 @@
 				<h2><span id="station-title"></span> <small>${stationName}</small></h2>
 				<div id="breadcrumbs">
 					<span>
-						<span><a href="http://www.gcmrc.gov/gcmrc.aspx">Home</a></span>
+						<span><a href="https://www.gcmrc.gov/gcmrc.aspx">Home</a></span>
 						<span> &gt; </span>
 						<span><a href="${relativePath}index.jsp">Discharge, Sediment and Water Quality</a></span>
 						<span> &gt; </span>


### PR DESCRIPTION
- missed some places last week when changing things that point to gcmrc.gov to use https instead
- adding https back on to the arcgisserveronline tile images because they *should* work fine, i see them when testing working just fine. in order to get rid of mixed content warnings