### PR TITLE
Increase binCount based on feedback from DT

### DIFF
--- a/gcmrc-ui/src/main/webapp/app/mapping.js
+++ b/gcmrc-ui/src/main/webapp/app/mapping.js
@@ -146,7 +146,7 @@ GCMRC.Mapping = function() {
 				})
 			}),
 		satmap : new OpenLayers.Layer.ArcGIS93Rest( "ArcGIS Server Layer",
-                "https://137.227.239.42/ArcGIS/rest/services/GC_2009_05_4BAND_EARTHDATA/ImageServer/exportImage",
+                "http://137.227.239.42/ArcGIS/rest/services/GC_2009_05_4BAND_EARTHDATA/ImageServer/exportImage",
                 {
 					layers: "show:0",
 					srs : "EPSG:26949"

--- a/gcmrc-ui/src/main/webapp/pages/stationview/page.js
+++ b/gcmrc-ui/src/main/webapp/pages/stationview/page.js
@@ -389,7 +389,7 @@ GCMRC.Page = {
 				var durationCurveOptions = {
 					startTime: begin,
 					endTime: end,
-					binCount: 200,
+					binCount: 1000,
 					binType: "both",
 					siteName: CONFIG.stationName
 				};
@@ -704,7 +704,7 @@ GCMRC.Page = {
 			startTime : beginClean,
 			endTime : endClean,
 			siteName : CONFIG.stationName,
-			binCount: "200",
+			binCount: "1000",
 			binType: $('input[name=bintype]:checked').val(),
 			groupId: ids,
 			groupName: names


### PR DESCRIPTION
David noticed today that for the duration curve plots, when we have areas where the values in a time series are low most of the time that we need more bins to display accurately the low values.

Trying to increase by a factor of 5, which was his suggestion.