### PR TITLE
modifying timeout for dygraphs as well as binCount

### DIFF
--- a/gcmrc-ui/src/main/webapp/app/graphing/graphing.js
+++ b/gcmrc-ui/src/main/webapp/app/graphing/graphing.js
@@ -708,7 +708,7 @@ GCMRC.Graphing = function(hoursOffset) {
 				dataType: 'json',
 				url: CONFIG.relativePath + urls[param],
 				data: urlParams,
-				timeout: 1200000, /* 20 minutes allowed, from start to data complete */
+				timeout: 2400000, /* 40 minutes allowed, from start to data complete */
 				success: function(data, textStatus, jqXHR) {
 					if (!data || (!data.contentType && data.contentType === "text/xml")) {
 						clearErrorMessage();

--- a/gcmrc-ui/src/main/webapp/pages/stationview/page.js
+++ b/gcmrc-ui/src/main/webapp/pages/stationview/page.js
@@ -389,7 +389,7 @@ GCMRC.Page = {
 				var durationCurveOptions = {
 					startTime: begin,
 					endTime: end,
-					binCount: 2000,
+					binCount: 1000,
 					binType: "both",
 					siteName: CONFIG.stationName
 				};
@@ -704,7 +704,7 @@ GCMRC.Page = {
 			startTime : beginClean,
 			endTime : endClean,
 			siteName : CONFIG.stationName,
-			binCount: "2000",
+			binCount: "1000",
 			binType: $('input[name=bintype]:checked').val(),
 			groupId: ids,
 			groupName: names


### PR DESCRIPTION
Based on discussion with David, time series that used to plot are timing out at 20 minutes. Trying this change to see if it helps to the dygraphs timeout -> 40 mins ..

Bin count could also be slowing things down, so he agreed to move it back to 1000 for now to see if that helps with performance time.