### PR TITLE
fix cumulative load rezeroing issue

### DIFF
--- a/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/column/ColumnResolver.java
+++ b/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/column/ColumnResolver.java
@@ -362,6 +362,10 @@ public class ColumnResolver {
 		//ugh. this is horrible.
 		result.put("inst!Sand Cumul Load", new ColumnMetadata("inst!Sand Cumul Load", "Cumulative Sand Load (Metric Tons)", 
 				new ColumnMetadata.SpecEntry(ParameterCode.parseParameterCode("inst!Sand Cumul Load"), ColumnMetadata.SpecEntry.SpecType.PARAM)));
+                
+                //need a shower after this.
+                result.put("inst!Calc Cumul Sand Bedload", new ColumnMetadata("inst!Calc Cumul Sand Bedload", "Calculated Cumulative Sand Bedload (Metric Tons)", 
+				new ColumnMetadata.SpecEntry(ParameterCode.parseParameterCode("inst!Calc Cumul Sand Bedload"), ColumnMetadata.SpecEntry.SpecType.PARAM)));
 		
 		
 		return result;

--- a/gcmrc-ui/src/main/webapp/pages/reachview/onReady.js
+++ b/gcmrc-ui/src/main/webapp/pages/reachview/onReady.js
@@ -26,7 +26,8 @@ $(document).ready(function onReady() {
 			GCMRC.Page.isBedloadIncluded = Boolean(parseFloat($("input[name=bedloadToggle]:checked").val()));
 			GCMRC.Page.bedloadToggleChange(GCMRC.Page.isBedloadIncluded);
 			$('#bedloadSlider').change(function(){
-				GCMRC.Page.bedloadToggleChange(GCMRC.Page.isBedloadIncluded);
+			    GCMRC.Page.isBedloadIncluded = Boolean(parseFloat($("input[name=bedloadToggle]:checked").val()));
+			    GCMRC.Page.bedloadToggleChange(GCMRC.Page.isBedloadIncluded);
 			});
         } else {
   


### PR DESCRIPTION
Introduced small bug that broke the bedload toggle, fixed.  Added cumulative sand bedload to column resolver hack, which resolved the
rezeroing issue and possible error bar handling for sand bedload.