### PR TITLE
Uintah zone correction for UI

### DIFF
--- a/gcmrc-ui/src/main/webapp/app/mapping.js
+++ b/gcmrc-ui/src/main/webapp/app/mapping.js
@@ -331,7 +331,7 @@ GCMRC.Mapping = function() {
 					yx : {'EPSG:900913' : false}
 				}
 			),
-			zone9272300 : new OpenLayers.Layer.WMS(
+			zone9261000 : new OpenLayers.Layer.WMS(
 				'Flow Lines',
 				CONFIG.relativePath + 'geoserver/sample/wms',
 				{


### PR DESCRIPTION
originally used incorrect stations for reach, fixed on geoserver and now pushing up changes to UI