### PR TITLE
GCMON-649: update comparison logic so discharge measurements don't exclude capitalized …

### DIFF
--- a/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/data/DischargeErrorSpec.java
+++ b/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/data/DischargeErrorSpec.java
@@ -96,7 +96,7 @@ public class DischargeErrorSpec extends DataSpec {
 		
 		if(this.parameterCode != null && this.parameterCode.sampleMethod != null) {
 			String sqlCleanMethod = cleanSql(this.parameterCode.sampleMethod);
-			result.append("  AND LOWER(DED.METHOD) = '" + sqlCleanMethod + "'");
+			result.append("  AND DED.METHOD = '" + sqlCleanMethod + "'");
 		}
 			
 		result.append(") T_A_INNER");

--- a/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/data/DischargeErrorSpec.java
+++ b/gcmrc-services/src/main/java/gov/usgs/cida/gcmrcservices/jsl/data/DischargeErrorSpec.java
@@ -52,7 +52,7 @@ public class DischargeErrorSpec extends DataSpec {
 		SearchMapping[] result = new SearchMapping[] {
 			new SearchMapping(ParameterSpec.S_SITE_NAME, C_SITE_NAME, null, WhereClauseType.equals, null, null, null),
 			new SearchMapping(ParameterSpec.S_GROUP_NAME, C_GROUP_NAME, null, WhereClauseType.equals, null, null, null),
-			new SearchMapping(S_METHOD_NAME, C_METHOD_NAME, null, WhereClauseType.equals, null, null, null),
+			new SearchMapping(S_METHOD_NAME, C_METHOD_NAME, null, WhereClauseType.equals, CleaningOption.addedWildcardSearch, null, null),
 			new SearchMapping(Endpoint.BEGIN_KEYWORD, C_SAMPLE_START_DT, null, WhereClauseType.special, CleaningOption.none, FIELD_NAME_KEY + " >= TO_DATE(" + USER_VALUE_KEY + ", 'YYYY-MM-DD\"T\"HH24:MI:SS')", null),
 			new SearchMapping(Endpoint.END_KEYWORD, C_SAMPLE_START_DT, null, WhereClauseType.special, CleaningOption.none, FIELD_NAME_KEY + " <= TO_DATE(" + USER_VALUE_KEY + ", 'YYYY-MM-DD\"T\"HH24:MI:SS')", null)
 		};


### PR DESCRIPTION
…methods

Previously was excluding capitalized methods like Estimate or Observation. Let the cooperators use whatever methods they want.

Also don't exclude methods with hyphens