### PR TITLE
GCMON-675: move GIS data in right pane above historical photos

### DIFF
--- a/gcmrc-ui/src/main/webapp/pages/index/onReady.js
+++ b/gcmrc-ui/src/main/webapp/pages/index/onReady.js
@@ -15,11 +15,11 @@ $(document).ready(function() {
 			if (GCMRC.Networks[key].topoSurveyId) {
 				networkDesc = networkDesc + '<li><a href="https://www.sciencebase.gov/catalog/item/'+ GCMRC.Networks[key].topoSurveyId +'">Topographic Surveys</li>';
 			}
-			if (GCMRC.Networks[key].photoItemId) {
-				networkDesc = networkDesc + '<li><a href="https://www.sciencebase.gov/catalog/item/'+ GCMRC.Networks[key].photoItemId +'">Historical Photographs</li>';
-			}
 			if (GCMRC.Networks[key].gisDataId) {
 				networkDesc = networkDesc + '<li><a href="https://www.sciencebase.gov/catalog/item/'+ GCMRC.Networks[key].gisDataId +'">GIS Data</li>';
+			}
+			if (GCMRC.Networks[key].photoItemId) {
+				networkDesc = networkDesc + '<li><a href="https://www.sciencebase.gov/catalog/item/'+ GCMRC.Networks[key].photoItemId +'">Historical Photographs</li>';
 			}
 			networkDesc = networkDesc + '</ul>';
 			$networkList.append(networkDesc)


### PR DESCRIPTION
Small mistake in ordering on the right hand pane. Move GIS data link above historical photo link to match the pop up order.