### PR TITLE
Add cursor pointer to footer

### DIFF
--- a/gcmrc-ui/src/main/webapp/template/common.css
+++ b/gcmrc-ui/src/main/webapp/template/common.css
@@ -133,6 +133,7 @@ footer.footer .footer-doi ul.menu li a {
     float: left;
     font-size: 12px;
     background-color: transparent;
+    cursor: pointer;
 }
 
 footer.footer .footer-doi ul.menu li:first-of-type {


### PR DESCRIPTION
doesn't appear in chrome without this, does appear in firefox/edge