### PR TITLE
 Added the ability to display a configurable warning notice at the top ...

### DIFF
--- a/gcmrc-ui/src/main/webapp/index.jsp
+++ b/gcmrc-ui/src/main/webapp/index.jsp
@@ -17,7 +17,7 @@
 		}
 	}
 	protected boolean development = Boolean.parseBoolean(props.getProperty("all.development")) || Boolean.parseBoolean(props.getProperty("${project.artifactId}.development"));
-
+	protected String warningMessage = props.getProperty("gcmrc.site.warning.message", "");
 %>
 
 <%
@@ -83,6 +83,9 @@
 				<div class="application-body">
 					<h2>Grand Canyon Monitoring and Research Center</h2>
 					<h3>Discharge, Sediment, and Water Quality Monitoring</h3>
+					<% if (!warningMessage.isEmpty()) { %>
+						<div class="alert alert-danger site-alert"><b>NOTICE:&nbsp;</b><%= warningMessage%></div>
+					<% } %>
 					<div id="breadcrumbs" class="row-fluid">
 						<span>
 							<span><a href="https://www.gcmrc.gov/gcmrc.aspx">Home</a></span>

--- a/gcmrc-ui/src/main/webapp/networkreachview.jsp
+++ b/gcmrc-ui/src/main/webapp/networkreachview.jsp
@@ -18,7 +18,7 @@
 	}
 	boolean development = Boolean.parseBoolean(props.getProperty("all.development")) || Boolean.parseBoolean(props.getProperty("${project.artifactId}.development"));
 	protected String warningMessage = props.getProperty("gcmrc.site.warning.message", "");
-	%>
+%>
 
 <%
 	request.setAttribute("development", development);

--- a/gcmrc-ui/src/main/webapp/networkreachview.jsp
+++ b/gcmrc-ui/src/main/webapp/networkreachview.jsp
@@ -17,7 +17,8 @@
 		}
 	}
 	boolean development = Boolean.parseBoolean(props.getProperty("all.development")) || Boolean.parseBoolean(props.getProperty("${project.artifactId}.development"));
-%>
+	protected String warningMessage = props.getProperty("gcmrc.site.warning.message", "");
+	%>
 
 <%
 	request.setAttribute("development", development);
@@ -92,6 +93,9 @@
 			<div class="application-body">
 				<h2>Grand Canyon Monitoring and Research Center</h2>
 				<h3><span class="network-name"></span> Reaches</h3>
+				<% if (!warningMessage.isEmpty()) { %>
+					<div class="alert alert-danger site-alert"><b>NOTICE:&nbsp;</b><%= warningMessage%></div>
+				<% } %>
 				<div id="breadcrumbs">
 					<span>
 						<span><a href="https://www.gcmrc.gov/gcmrc.aspx">Home</a></span>

--- a/gcmrc-ui/src/main/webapp/networkstationview.jsp
+++ b/gcmrc-ui/src/main/webapp/networkstationview.jsp
@@ -17,6 +17,7 @@
 		}
 	}
 	boolean development = Boolean.parseBoolean(props.getProperty("all.development")) || Boolean.parseBoolean(props.getProperty("${project.artifactId}.development"));
+	protected String warningMessage = props.getProperty("gcmrc.site.warning.message", "");
 %>
 
 <%
@@ -101,6 +102,9 @@
 				<div class="application-body">
 					<h2>Grand Canyon Monitoring and Research Center</h2>
 					<h3><span class="network-name"></span> Stations</h3>
+					<% if (!warningMessage.isEmpty()) { %>
+						<div class="alert alert-danger site-alert"><b>NOTICE:&nbsp;</b><%= warningMessage%></div>
+					<% } %>
 					<div id="breadcrumbs">
 						<span>
 							<span><a href="https://www.gcmrc.gov/gcmrc.aspx">Home</a></span>

--- a/gcmrc-ui/src/main/webapp/reachview.jsp
+++ b/gcmrc-ui/src/main/webapp/reachview.jsp
@@ -17,6 +17,7 @@
 		}
 	}
 	boolean development = Boolean.parseBoolean(props.getProperty("all.development")) || Boolean.parseBoolean(props.getProperty("${project.artifactId}.development"));
+	protected String warningMessage = props.getProperty("gcmrc.site.warning.message", "");
 
 %>
 
@@ -176,6 +177,9 @@
 				<!--				</div>-->
 				<h2>Grand Canyon Monitoring and Research Center</h2>
 				<h3><span id="station-title"></span> <small id="station-subtitle"></small></h3>
+				<% if (!warningMessage.isEmpty()) { %>
+					<div class="alert alert-danger site-alert"><b>NOTICE:&nbsp;</b><%= warningMessage%></div>
+				<% } %>
 				<div id="breadcrumbs">
 					<span>
 						<span><a href="https://www.gcmrc.gov/gcmrc.aspx">Home</a></span>

--- a/gcmrc-ui/src/main/webapp/stationview.jsp
+++ b/gcmrc-ui/src/main/webapp/stationview.jsp
@@ -17,6 +17,7 @@
 		}
 	}
 	boolean development = Boolean.parseBoolean(props.getProperty("all.development")) || Boolean.parseBoolean(props.getProperty("${project.artifactId}.development"));
+	protected String warningMessage = props.getProperty("gcmrc.site.warning.message", "");
 
 %>
 
@@ -173,6 +174,9 @@
 			<div>
 				<h2>Grand Canyon Monitoring and Research Center</h2>				
 				<h3><span id="station-title"></span> <small>${stationName}</small></h3>
+				<% if (!warningMessage.isEmpty()) { %>
+					<div class="alert alert-danger site-alert"><b>NOTICE:&nbsp;</b><%= warningMessage%></div>
+				<% } %>
 				<div id="breadcrumbs">
 					<span>
 						<span><a href="https://www.gcmrc.gov/gcmrc.aspx">Home</a></span>

--- a/gcmrc-ui/src/main/webapp/template/custom.css
+++ b/gcmrc-ui/src/main/webapp/template/custom.css
@@ -991,12 +991,13 @@ By default, USGS has set the font size, family, etc. in order to provide a consi
 /* THIS HIDES THE SEARCH BOX ON VERY SMALL DEVICES:
 For simplification, search bar is visible on larger screens but is hidden on small screens. If you would prefer not to have the search box at all, you can remove the "@media (max-width:500px) {" and the second closing "}". below */
 .header-search form { 
-	display: none}
+	display: none
 }
 /* =============SOCIAL MEDIA===============*/ 
 /* If you would prefer not to have the social media links, you can remove the comment out slashes and astricks surrounding the content below */
- .footer-social-links { 
-    display: none} 
+.footer-social-links { 
+    display: none
+} 
     
 .site-alert {
     font-size: 26px;

--- a/gcmrc-ui/src/main/webapp/template/custom.css
+++ b/gcmrc-ui/src/main/webapp/template/custom.css
@@ -996,4 +996,8 @@ For simplification, search bar is visible on larger screens but is hidden on sma
 /* =============SOCIAL MEDIA===============*/ 
 /* If you would prefer not to have the social media links, you can remove the comment out slashes and astricks surrounding the content below */
  .footer-social-links { 
-	display: none} 
+    display: none} 
+    
+.site-alert {
+    font-size: 26px;
+}


### PR DESCRIPTION
… of all page of the site.

A few notes:

1. The message automatically has a bold "NOTICE: " prepended to it. Not sure if we want that or not, so I can remove it if it's not desired.

2. The message is setup to display in the red "danger" alert style. I could make this configurable as well if desired, but I couldn't think of a situation where a site-wide message wouldn't be a warning of some sort.

3. The context.xml environment `gcmrc.site.warning.message` is used to set the message. If the value is empty (`value=""`) or not defined then no message will be displayed. Any other defined value will result in a message being shown. E.X: `value="It's down."` --> `NOTICE: It's down.`