### PR TITLE
Add source filtering for js files using Closure.

### DIFF
--- a/gcmrc-ui/pom.xml
+++ b/gcmrc-ui/pom.xml
@@ -129,10 +129,23 @@
 		</resources>
 		<pluginManagement>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-war-plugin</artifactId>
-			</plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>3.2.3</version>
+                        <configuration>
+                            <webResources>
+                                <resource>
+                                    <directory>src/main/webapp</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>app/graphing/matrixFinesWorker.js</include>
+                                        <include>app/graphing/matrixSandWorker.js</include>
+                                    </includes>
+                                </resource>
+                            </webResources>
+                        </configuration>
+                    </plugin>
                         <plugin>
                             <groupId>com.github.klieber</groupId>
                             <artifactId>phantomjs-maven-plugin</artifactId>

--- a/gcmrc-ui/src/main/webapp/app/graphing/matrixFinesWorker.js
+++ b/gcmrc-ui/src/main/webapp/app/graphing/matrixFinesWorker.js
@@ -2,7 +2,6 @@ var closureLocation = "../../webjars/closure-library/${version.closure}/goog";
 importScripts(
         closureLocation + "/base.js",
         closureLocation + "/deps.js",
-        closureLocation + "/deps.js",
         closureLocation + "/debug/error.js",
         closureLocation + "/string/string.js",
         closureLocation + "/asserts/asserts.js",

--- a/gcmrc-ui/src/main/webapp/app/graphing/matrixFinesWorker.js
+++ b/gcmrc-ui/src/main/webapp/app/graphing/matrixFinesWorker.js
@@ -1,14 +1,18 @@
-importScripts("../../js/closure-library/goog/base.js", 
-"../../js/closure-library/goog/debug/error.js",
-"../../js/closure-library/goog/string/string.js",
-"../../js/closure-library/goog/asserts/asserts.js",
-"../../js/closure-library/goog/array/array.js",
-"../../js/closure-library/goog/math/math.js",
-"../../js/closure-library/goog/math/size.js",
-"../../js/closure-library/goog/math/matrix.js"
-);
+var closureLocation = "../../webjars/closure-library/${version.closure}/goog"
+importScripts(
+        closureLocation + "/base.js",
+        closureLocation + "/deps.js",
+        closureLocation + "/deps.js",
+        closureLocation + "/debug/error.js",
+        closureLocation + "/string/string.js",
+        closureLocation + "/asserts/asserts.js",
+        closureLocation + "/array/array.js",
+        closureLocation + "/math/math.js",
+        closureLocation + "/math/size.js",
+        closureLocation + "/math/matrix.js"
+        );
 
-importScripts("../../js/sugar/sugar-1.3.9.min.js");
+importScripts("../../webjars/sugar/${version.sugarjs}/sugar-full.min.js");
 importScripts("../../js/js-utils/binary-search.js");
 
 importScripts("../../app/graphing/MatrixWorker.js");

--- a/gcmrc-ui/src/main/webapp/app/graphing/matrixFinesWorker.js
+++ b/gcmrc-ui/src/main/webapp/app/graphing/matrixFinesWorker.js
@@ -1,4 +1,4 @@
-var closureLocation = "../../webjars/closure-library/${version.closure}/goog"
+var closureLocation = "../../webjars/closure-library/${version.closure}/goog";
 importScripts(
         closureLocation + "/base.js",
         closureLocation + "/deps.js",

--- a/gcmrc-ui/src/main/webapp/app/graphing/matrixSandWorker.js
+++ b/gcmrc-ui/src/main/webapp/app/graphing/matrixSandWorker.js
@@ -1,14 +1,17 @@
-importScripts("../../js/closure-library/goog/base.js", 
-"../../js/closure-library/goog/debug/error.js",
-"../../js/closure-library/goog/string/string.js",
-"../../js/closure-library/goog/asserts/asserts.js",
-"../../js/closure-library/goog/array/array.js",
-"../../js/closure-library/goog/math/math.js",
-"../../js/closure-library/goog/math/size.js",
-"../../js/closure-library/goog/math/matrix.js"
-);
+var closureLocation = "../../webjars/closure-library/${version.closure}/goog"
+importScripts(
+        closureLocation + "/base.js",
+        closureLocation + "/deps.js",
+        closureLocation + "/debug/error.js",
+        closureLocation + "/string/string.js",
+        closureLocation + "/asserts/asserts.js",
+        closureLocation + "/array/array.js",
+        closureLocation + "/math/math.js",
+        closureLocation + "/math/size.js",
+        closureLocation + "/math/matrix.js"
+        );
 
-importScripts("../../js/sugar/sugar-1.3.9.min.js");
+importScripts("../../webjars/sugar/${version.sugarjs}/sugar-full.min.js");
 importScripts("../../js/js-utils/binary-search.js");
 
 importScripts("../../app/graphing/MatrixWorker.js");

--- a/gcmrc-ui/src/main/webapp/app/graphing/matrixSandWorker.js
+++ b/gcmrc-ui/src/main/webapp/app/graphing/matrixSandWorker.js
@@ -1,4 +1,4 @@
-var closureLocation = "../../webjars/closure-library/${version.closure}/goog"
+var closureLocation = "../../webjars/closure-library/${version.closure}/goog";
 importScripts(
         closureLocation + "/base.js",
         closureLocation + "/deps.js",


### PR DESCRIPTION
Because GCMRC uses Closure in two files, creating WebWorkers, there's no way to dynamically tell the import statements where the webjars resources are located. 

One way we can inject the location is to re-write the two .js files during the building of the project in the same way that we already do for application.properties.

However, to do this, we need to add configuration to the `maven-war-plugin` instead of depending on the typical Maven Resources plugin. This is because when using the latter, js files end up in the wrong spot in the application. The maven-war-plugin performs the same type of filtering, but for web resources like js files.