### PR TITLE
Fix for station loading JSONP callback

### DIFF
--- a/gcmrc-ui/src/main/webapp/networkreachview.jsp
+++ b/gcmrc-ui/src/main/webapp/networkreachview.jsp
@@ -63,6 +63,7 @@
 		</script>
 
 		<jsp:include page="app/gcmrc.jsp"></jsp:include>
+                <script src="${relativePath}services/rest/station/site/${networkName}?jsonp_callback=GCMRC.StationLoad"></script>
 		<jsp:include page="pages/page.jsp">
 			<jsp:param name="relPath" value="${relativePath}" />
 			<jsp:param name="pageName" value="${pageName}" />

--- a/gcmrc-ui/src/main/webapp/reachview.jsp
+++ b/gcmrc-ui/src/main/webapp/reachview.jsp
@@ -79,7 +79,6 @@
 		</jsp:include>
 
                 <jsp:include page="js/proj4js/package.jsp"></jsp:include>
-
 		<script src="${relativePath}app/DeclusterCanvas.js" type="text/javascript"></script>
 			
 		<jsp:include page="js/dygraphs/dygraphs.jsp">
@@ -100,6 +99,7 @@
 		</script>
 
 		<jsp:include page="app/gcmrc.jsp"></jsp:include>
+                <script src="${relativePath}services/rest/station/allsite/${networkName}?jsonp_callback=GCMRC.StationLoad"></script>
 		<jsp:include page="js/angular-sortable/package.jsp">
 			<jsp:param name="relPath" value="${relativePath}" />
 			<jsp:param name="debug-qualifier" value="${development}" />


### PR DESCRIPTION
I introduced a bug in my rework for introducing webjars by removing a line from two JSP files which loads stations from the back-end. This created an issue where the map had no stations on two views and showed no data. 

I've re-added the station load call and it seems to be fine now